### PR TITLE
Fix I2C_ReadBuffer uint8_t underflow when Size=0

### DIFF
--- a/src/driver/i2c.c
+++ b/src/driver/i2c.c
@@ -137,6 +137,9 @@ int I2C_ReadBuffer(void *pBuffer, uint8_t Size)
     uint8_t *pData = (uint8_t *)pBuffer;
     uint8_t i;
 
+    if (Size == 0)
+        return 0;
+
     for (i = 0; i < Size - 1; i++) {
         SYSTICK_DelayUs(1);
         pData[i] = I2C_Read(false);


### PR DESCRIPTION
When Size is 0, the loop condition `i < Size - 1` wraps to 255 due to unsigned underflow, causing 256 bytes to be written into the caller's buffer. Add early return guard.

Bug: C-1 in BUGS.md